### PR TITLE
Update Deluge libtorrent version numbers

### DIFF
--- a/setup/quickbox-setup
+++ b/setup/quickbox-setup
@@ -255,14 +255,14 @@ function _askrtorrent() {
 # ask deluge version (if wanted) (8.1)
 function _askdeluge() {
   echo -e "1) Deluge ${green}repo${normal} (fastest)"
-  echo -e "2) Deluge with ${green}libtorrent 1.0.9 (stable)${normal}"
-  echo -e "3) Deluge with ${green}libtorrent 1.1.1 (dev)${normal}"
+  echo -e "2) Deluge with ${green}libtorrent 1.0.11 (stable)${normal}"
+  echo -e "3) Deluge with ${green}libtorrent 1.1.3 (dev)${normal}"
   echo -e "4) Do not install Deluge"
   echo -ne "${bold}${yellow}What version of Deluge do you want?${normal} (Default ${green}1${normal}): "; read version
   case $version in
     1 | "") DELUGE=REPO  ;;
-    2) DELUGE=1.0.9  ;;
-    3) DELUGE=1.1.1 ;;
+    2) DELUGE=1.0.11  ;;
+    3) DELUGE=1.1.3 ;;
     4) DELUGE=NO ;;
     *) DELUGE=REPO ;;
   esac
@@ -621,10 +621,10 @@ function _deluge() {
     systemctl stop deluged
     update-rc.d deluged remove
     rm /etc/init.d/deluged
-  elif [[ $DELUGE == 1.0.9 ]] || [[ $DELUGE == 1.1.1 ]]; then
-    if [[ $DELUGE == 1.0.9 ]]; then
+  elif [[ $DELUGE == 1.0.11 ]] || [[ $DELUGE == 1.1.3 ]]; then
+    if [[ $DELUGE == 1.0.11 ]]; then
       LTRC=RC_1_0
-    elif [[ $DELUGE == 1.1.1 ]]; then
+    elif [[ $DELUGE == 1.1.3 ]]; then
       LTRC=RC_1_1
     fi
   apt-get -qy update >/dev/null 2>&1


### PR DESCRIPTION
Keep users from complaining about being outdated, when they're not. I'll try to find a way to automate version number grabbing.