### PR TITLE
VPN port

### DIFF
--- a/packages/system/quickVPN
+++ b/packages/system/quickVPN
@@ -385,7 +385,7 @@ dev tun
 proto udp
 sndbuf 0
 rcvbuf 0
-remote $IP $OVPNPORT
+remote $IP $PORT
 resolv-retry infinite
 nobind
 persist-key


### PR DESCRIPTION
when the user decide to set a custom port instead of the one generated, the client config still use the generated one.