### PR TITLE
Update Jackett install script for external use

### DIFF
--- a/packages/package/install/installpackage-jackett
+++ b/packages/package/install/installpackage-jackett
@@ -65,6 +65,19 @@ AuthUserFile '/etc/htpasswd'
 Require user ${username}
 </Location>
 EOF
+
+# Write public IP to ProxyPass if user will be using Jackett remotely.
+# Ask user what they want to do.
+echo "Should Jackett be setup for internal use only (localhost) or external use (IP address)?"
+# Input should be either "int" for internal use (do nothing) or "ext" for external use (change ProxyPass).
+read -p 'int/ext: ' ipvar
+if [ "$ipvar" = "ext" ]; then
+  ip_ext=$(wget -qO- http://ipecho.net/plain)
+  ip_int="localhost"
+  sed -i "s~ProxyPass http://${ip_int}:9117/jackett~ProxyPass http://${ip_ext}:9117/jackett~" /etc/apache2/sites-enabled/jackett.conf
+  sed -i "s/\"AllowExternal.*/\"AllowExternal\": true,/g" /home/${username}/.config/Jackett/ServerConfig.json
+fi
+
 chown www-data: /etc/apache2/sites-enabled/jackett.conf
 service apache2 reload
 service jackett@${username} start


### PR DESCRIPTION
Added a new section to the script to ask the user if they want to be using jackett outside their network, or just inside their network. Resolves https://plaza.quickbox.io/t/jackett-download-issue/2930