### PR TITLE
Add prompt for Sonarr compatibility

### DIFF
--- a/packages/package/install/installpackage-jackett
+++ b/packages/package/install/installpackage-jackett
@@ -68,6 +68,7 @@ EOF
 
 # Write public IP to ProxyPass if user will be using Jackett remotely.
 # Ask user what they want to do.
+
 echo "Should Jackett be setup for internal use only (localhost) or external use (IP address)?"
 # Input should be either "int" for internal use (do nothing) or "ext" for external use (change ProxyPass).
 read -p 'int/ext: ' ipvar
@@ -76,6 +77,14 @@ if [ "$ipvar" = "ext" ]; then
   ip_int="localhost"
   sed -i "s~ProxyPass http://${ip_int}:9117/jackett~ProxyPass http://${ip_ext}:9117/jackett~" /etc/apache2/sites-enabled/jackett.conf
   sed -i "s/\"AllowExternal.*/\"AllowExternal\": true,/g" /home/${username}/.config/Jackett/ServerConfig.json
+  # Ask the user if they'll want to use Sonarr/Radarr. If yes, disable digest auth from Jackett to enable it to work with those services. If no, move on.
+  echo "Will you be using Sonarr or Radarr with Jackett?"
+  read -p 'yes/no: ' sonarrvar
+  if [ "$sonarrvar" = "yes" ]; then
+  # Backup file available at /etc/apache2/sites-enabled/jackett.conf.bak
+  sed -i.bak -e '4,7d' /etc/apache2/sites-enabled/jackett.conf
+  echo "Note: Digest auth has been disabled to make Sonarr work. You should enable a password withing the Jackett WebUI."
+  fi
 fi
 
 chown www-data: /etc/apache2/sites-enabled/jackett.conf


### PR DESCRIPTION
Add new prompt asking user if they'll be using Sonarr or Radarr. Since there's no way for either to read digest auth, prompt will disable digest auth if user says "yes" to using Sonarr. Should remove some headaches for users.