### PR TITLE
Change jackett path in menu

### DIFF
--- a/themes/defaulted/inc/config.php
+++ b/themes/defaulted/inc/config.php
@@ -294,7 +294,7 @@ if(file_exists('/srv/rutorrent/home/custom/url.override.php')){
   if ($dwssl == "true") { $dwURL = "https://" . $_SERVER['HTTP_HOST'] . ":$dwport"; }
   if ($dwssl == "false") { $dwURL = "http://" . $_SERVER['HTTP_HOST'] . ":$dwport"; }
   $embyURL = "https://" . $_SERVER['HTTP_HOST'] . "/emby";
-  $jackettURL = "https://" . $_SERVER['HTTP_HOST'] . "/jackett/Admin/Dashboard";
+  $jackettURL = "https://" . $_SERVER['HTTP_HOST'] . "/jackett/";
   $nextcloudURL = "https://" . $_SERVER['HTTP_HOST'] . "/nextcloud";
   $nzbhydraURL = "https://" . $_SERVER['HTTP_HOST'] . "/nzbhydra";
   $plexURL = "http://" . $_SERVER['HTTP_HOST'] . ":31400/web/";


### PR DESCRIPTION
Right now the jackett link shows to /jackett/Admin/Dashboard, it seems as if in one of the last releases Jackett changed that to /UI/Dashboard or /jackett/UI/Dashboard, but /jackett/ seems to redirect just fine. (not /jackett though for me)

If true: Same change in other theme