### PR TITLE
Move headphones.pid to user directory

### DIFF
--- a/setup/templates/sysd/headphones.template
+++ b/setup/templates/sysd/headphones.template
@@ -4,8 +4,8 @@ Wants=network.target network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/usr/bin/python2 /home/USER/.headphones/Headphones.py -d --pidfile /var/run/headphones/headphones.pid --datadir /home/USER/.headphones --nolaunch --config /home/USER/.headphones/config.ini --port 8004
-PIDFile=/var/run/headphones/headphones.pid
+ExecStart=/usr/bin/python2 /home/USER/.headphones/Headphones.py -d --pidfile /home/USER/.headphones/headphones.pid --datadir /home/USER/.headphones --nolaunch --config /home/USER/.headphones/config.ini --port 8004
+PIDFile=/home/USER/.headphones/headphones.pid
 Type=forking
 User=USER
 Group=USER


### PR DESCRIPTION
Headphones is unable to start after a server reboot because /var/run is tmpfs and the headphones directory is removed.

The directory can be added with systemd by adding:
`PermissionsStartOnly=true`
`RuntimeDirectory=headphones`
`RuntimeDirectoryMode=0755`

However I feel since it is run as user it can stay in its directory like nzbhydra does with its own PID.