### PR TITLE
Fix autodl-irssi script

### DIFF
--- a/packages/package/install/installpackage-autodl
+++ b/packages/package/install/installpackage-autodl
@@ -31,7 +31,7 @@ local_setup=/etc/QuickBox/setup/
 
 function _installautodl() {
   rutorrent="/srv/rutorrent/";
-  PLUGINVAULT="/etc/QuickBox/rtplugins"; cd "${rutorrent}plugins"
+  PLUGINVAULT="/etc/QuickBox/rtplugins/"; cd "${rutorrent}plugins"
   PLUGIN="autodl-irssi"
   #users=($(cat /etc/htpasswd | cut -d ":" -f 1))
     for i in $PLUGIN; do


### PR DESCRIPTION
Fixes the following error:

`cp: cannot stat '/etc/QuickBox/rtpluginsautodl-irssi': No such file or directory`

Caused by a missing trailing forward slash.