### PR TITLE
More autodl-irssi fixes

### DIFF
--- a/packages/package/install/installpackage-autodl
+++ b/packages/package/install/installpackage-autodl
@@ -33,12 +33,11 @@ function _installautodl() {
   rutorrent="/srv/rutorrent/";
   PLUGINVAULT="/etc/QuickBox/rtplugins/"; cd "${rutorrent}plugins"
   PLUGIN="autodl-irssi"
-  #users=($(cat /etc/htpasswd | cut -d ":" -f 1))
     for i in $PLUGIN; do
       cp -R "${PLUGINVAULT}$i" .
       chown -R www-data: ${rutorrent}plugins/$PLUGIN
     done
-    for u in "${users[@]}"; do
+    for u in "$(cat /etc/htpasswd | cut -d ':' -f 1 | uniq)"; do
       IRSSI_PASS=$(_string)
       IRSSI_PORT=$(shuf -i 20000-61000 -n 1)
       mkdir -p "/home/${u}/.irssi/scripts/autorun/" >>"${OUTTO}" 2>&1

--- a/packages/package/install/installpackage-autodl
+++ b/packages/package/install/installpackage-autodl
@@ -54,6 +54,14 @@ gui-server-port = ${IRSSI_PORT}
 gui-server-password = ${IRSSI_PASS}
 ADC
 
+CONFPATH="/srv/rutorrent/conf/users/${u}/plugins/autodl-irssi/"
+mkdir -p CONFPATH
+cat >"/srv/rutorrent/conf/users/${u}/plugins/autodl-irssi/conf.php"<<<ADC
+<?php
+$autodlPort = ${IRSSI_PORT};
+$autodlPassword = ${IRSSI_PASS};
+?>
+ADC
       chown -R "${u}.${u}" "/home/${u}/.irssi/"
       chown -R "${u}.${u}" "/home/${u}"
     done


### PR DESCRIPTION
I noticed the users list wasn't being made so this script just wouldn't do anything. This should be fixed. now with e5b3b2a.

Also, based on the autodl-rutorrent setup, a config file needs to be saved to indicate the port number and password. This isn't saved anywhere though - not sure if it's set up somewhere else so I added it here in 771d942. This is untested though.

Not sure this is ready for merge -- What is `_string`? Right now this just causes errors and no irssi password is generated.